### PR TITLE
OSW-1277: Updated ts-conda-build dependency version and conda build string.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -9,10 +9,11 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
+  string: "py{{ PY_VER | replace('.', '') }}{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"
 
 test:
   requires:
-    - ts-conda-build =0.4
+    - ts-conda-build =0.5
     - ts-tcpip
     - ts-utils
     - ts-xml

--- a/doc/news/OSW-1277.perf.rst
+++ b/doc/news/OSW-1277.perf.rst
@@ -1,0 +1,1 @@
+Updated ts-conda-build dependency version and conda build string.

--- a/doc/news/README.rst
+++ b/doc/news/README.rst
@@ -1,0 +1,45 @@
+Recording Changes
+=================
+
+This directory contains "news fragments" which are small, structured text files that contain information about changes or updates that will be included in the release notes.
+These fragments are used to automatically generate changelogs or release notes.
+They can be written restructured text format or plain text.
+
+Each file should be named like ``<JIRA TICKET>.<TYPE>.<EXT>`` with a file extension defining the markup format (``rst|md``).
+The ``<TYPE>`` should be one of:
+
+* ``feature``: A new feature
+* ``bugfix``: A bug fix.
+* ``perf``: A performance enhancement.
+* ``doc``: A documentation improvement.
+* ``removal``: A deprecation or removal of API.
+* ``misc``: Other minor changes and/or additions
+
+An example file name would therefore look like ``OSW-40534.doc.rst``.
+
+Each developer now has to create the news fragments for the changes they have made on their own branches, instead of adding them to the release notes directly.
+You can create new fragments using the ``towncrier create`` command, which will help you to create a new news fragment file with the correct naming convention and numbering:
+
+.. code-block:: bash
+
+   $ towncrier create -c "<News fragment message>" OSW-XXXXX.<fragment type>.rst
+
+The news fragments are then automatically integrated into the release notes by the ``towncrier`` tool.
+
+You can test how the content will be integrated into the release notes by running ``towncrier build --draft --version=v<X.XX.X>``.
+Note that you have to run it from the root repository directory (i.e. ``ts_atbuilding_vents``).
+
+In order to update the release notes file for real, the person responsible for the release should run:
+
+.. code-block:: bash
+
+   $ towncrier build --version=v<X.XX.X>
+
+
+.. note::
+
+   When running towncrier to build the changelog, you may be prompted to confirm the deletion of fragments.
+   If you would like to retain the fragments in the doc/news directory do not confirm the deletion.
+
+Note also that ``towncrier`` can be installed from PyPI or conda-forge.
+


### PR DESCRIPTION
This PR also moves the project over to towncrier for changelog tracking.